### PR TITLE
CFE-2768 Initial acceptance tests for classexpression_filterdata()

### DIFF
--- a/tests/acceptance/01_vars/02_functions/classexpression_filterdata_1.cf
+++ b/tests/acceptance/01_vars/02_functions/classexpression_filterdata_1.cf
@@ -1,0 +1,49 @@
+body common control
+{
+        inputs => { "../../default.cf.sub" };
+        bundlesequence  => { default("$(this.promise_filename)") };
+        version => "1.0";
+}
+
+bundle agent test
+{
+  meta:
+      "description" -> { "CFE-2768" }
+        string => "Test that classexpression_filterdata() works with column headings filtered by first column.";
+
+}
+bundle agent check
+{
+  vars:
+      "data_file" string => "$(this.promise_filename).csv";
+      "d" data => classexpression_filterdata( $(data_file),
+                                              0,      # Column containing class expression to filter with
+                                              ",",    # Delim (NOT IMPLEMENTED AT TIME OF TEST)
+                                              "true", # Data file contains column headings
+                                              1);     # Column to sort by (NOT IMPLEMENTED AT TIME OF TEST)
+
+  classes:
+
+      # Check if Token has the value we expect
+      "Token_OK" expression => strcmp( "$(d[0][Token])", "net.ipv4.ip_forward" );
+
+      # Check if Value has the value we expect
+      "Value_OK" expression => strcmp( "$(d[0][Value])", "0" );
+
+      # Check if the result contains the number of records we expect.
+      "Length_OK" expression => strcmp( length( d ), 1 );
+
+      # Check if all of our checks are as expected.
+      "TokenValueLength_OK"
+        and => { "Token_OK", "Value_OK", "Length_OK" },
+        scope => "namespace";
+
+  methods:
+
+      "Pass/FAIL"
+        usebundle => dcs_passif( 'TokenValueLength_OK', $(this.promise_filename) );
+
+  reports:
+      DEBUG|EXTRA::
+        "Function returned:$(with)" with => string_mustache( "{{%-top-}}", d );
+}

--- a/tests/acceptance/01_vars/02_functions/classexpression_filterdata_1.cf.csv
+++ b/tests/acceptance/01_vars/02_functions/classexpression_filterdata_1.cf.csv
@@ -1,0 +1,3 @@
+#ClassExpr,Sort,Token,Value
+any,1,net.ipv4.ip_forward,0
+supercalifragilisticexpialidociousNOTDEFINED,1,net.ipv4.ip_forward,1


### PR DESCRIPTION
This intention with this very naive test is to provide a baseline for
development iteration. It does not cover all cases and is not very strict.

This tests:

    That the function filters based on a class and returns the expected number of
    results.
    That the function properly extracts headers and values.

Changelog: None